### PR TITLE
[1t7hyku] Add field correctAnswerCount in mutation sendAnswerAndGetNextQuestion

### DIFF
--- a/app/graphql/types/send_answer_and_get_next_question_type.rb
+++ b/app/graphql/types/send_answer_and_get_next_question_type.rb
@@ -1,5 +1,6 @@
 module Types
   class SendAnswerAndGetNextQuestionType < Types::BaseObject
+    field :correct_answers_count, Integer, null: false
     field :correct_answer_value, String, null: false
     field :question, Types::TeamMemberType, null: false
   end

--- a/app/interactors/send_answer_and_get_next_question.rb
+++ b/app/interactors/send_answer_and_get_next_question.rb
@@ -7,5 +7,6 @@ class SendAnswerAndGetNextQuestion
            SendAnswerAndGetNextQuestion::UpdateResultScore,
            SendAnswerAndGetNextQuestion::PrepareQuestionParams,
            FindRandomQuestion,
-           CreateResultAnswer
+           CreateResultAnswer,
+           SendAnswerAndGetNextQuestion::SetCorrectAnswersCount
 end

--- a/app/interactors/send_answer_and_get_next_question/set_correct_answers_count.rb
+++ b/app/interactors/send_answer_and_get_next_question/set_correct_answers_count.rb
@@ -1,0 +1,18 @@
+class SendAnswerAndGetNextQuestion
+  class SetCorrectAnswersCount
+    include Interactor
+
+    delegate :result, to: :context
+    delegate :question, to: :answer
+
+    def call
+      context.correct_answers_count = correct_answers_count
+    end
+
+    private
+
+    def correct_answers_count
+      @correct_answers_count ||= result.answers.correct.count
+    end
+  end
+end

--- a/app/interactors/send_answer_and_get_next_question/set_correct_answers_count.rb
+++ b/app/interactors/send_answer_and_get_next_question/set_correct_answers_count.rb
@@ -3,7 +3,6 @@ class SendAnswerAndGetNextQuestion
     include Interactor
 
     delegate :result, to: :context
-    delegate :question, to: :answer
 
     def call
       context.correct_answers_count = correct_answers_count

--- a/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
+++ b/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
@@ -1,16 +1,16 @@
 {
   "data": {
     "sendAnswerAndGetNextQuestion": {
-      "correctAnswersCount": "correct_answers_count",
-      "correctAnswerValue": ":correct_answer_value",
+      "correctAnswersCount": :correctAnswersCount,
+      "correctAnswerValue": ":correctAnswerValue",
       "question": {
         "answerOptions": [
           "Ural Sadritdinov",
-          "FullName3",
           "FullName1",
+          "FullName3",
           "FullName2"
         ],
-        "avatarUrl": ":avatar_url"
+        "avatarUrl": ":avatarUrl"
       }
     }
   }

--- a/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
+++ b/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
@@ -1,8 +1,8 @@
 {
   "data": {
     "sendAnswerAndGetNextQuestion": {
-      "correctAnswersCount": :correctAnswersCount,
-      "correctAnswerValue": ":correctAnswerValue",
+      "correctAnswersCount": 2,
+      "correctAnswerValue": "Ural Sadritdinov",
       "question": {
         "answerOptions": [
           "Ural Sadritdinov",

--- a/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
+++ b/spec/fixtures/json/acceptance/graphql/send_answer_and_get_next_question/success.json
@@ -1,13 +1,14 @@
 {
   "data": {
     "sendAnswerAndGetNextQuestion": {
+      "correctAnswersCount": "correct_answers_count",
       "correctAnswerValue": ":correct_answer_value",
       "question": {
         "answerOptions": [
+          "Ural Sadritdinov",
+          "FullName3",
           "FullName1",
-          "FullName4",
-          "FullName2",
-          "FullName3"
+          "FullName2"
         ],
         "avatarUrl": ":avatar_url"
       }

--- a/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
+++ b/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
-  include_context "with stubbed activerecord default order", model: Question, order: { full_name: :asc }
   let(:user) { create :user }
 
   let(:execution_context) { { context: { current_user: user } } }
@@ -9,7 +8,7 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
 
   let(:image_path) { "spec/fixtures/images/avatar.jpg" }
 
-  let(:question) { create :question, full_name: "FullName3" }
+  let(:question) { create :question, full_name: "Ural Sadritdinov" }
   let(:result) { create :result, user: user, finish_at: 10.minutes.since }
   let!(:answer) { create :answer, correct: false, result: result, question: question, value: nil }
 
@@ -22,6 +21,7 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
         value: "Ural Sadritdinov"
       }
     ) {
+        correctAnswersCount
         correctAnswerValue
         question {
           answerOptions
@@ -35,7 +35,7 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
   before do
     create :question, full_name: "FullName1"
     create :question, full_name: "FullName2"
-    create :question, full_name: "FullName4"
+    create :question, full_name: "FullName3"
     srand(777)
     question.avatar = File.open(Rails.root.join(image_path), "rb")
     question.avatar_derivatives!
@@ -47,9 +47,10 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
 
     let(:prepared_fixture_file) do
       fixture_file.gsub(
-        /:avatar_url|:correct_answer_value/,
+        /:avatar_url|:correct_answer_value|:correct_answers_count/,
         ":avatar_url" => question.avatar(:normal).url,
-        ":correct_answer_value" => answer.question.full_name
+        ":correct_answer_value" => answer.question.full_name,
+        ":correct_answers_count" => result.answers.correct.count
       )
     end
   end

--- a/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
+++ b/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
@@ -7,10 +7,13 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
   let(:schema_context) { { current_user: user } }
 
   let(:image_path) { "spec/fixtures/images/avatar.jpg" }
+
+  let(:old_question) { create :question, full_name: "FullName1" }
   let(:new_question) { create :question, full_name: "FullName2" }
   let(:question) { create :question, full_name: "Ural Sadritdinov" }
   let(:result) { create :result, user: user, finish_at: 10.minutes.since }
-  let!(:answer) { create :answer, correct: false, result: result, question: question, value: nil }
+  let!(:answer_1) { create :answer, correct: false, result: result, question: question, value: nil }
+  let!(:answer_2) { create :answer, correct: true, result: result, question: old_question }
 
   let(:query) do
     <<-GRAPHQL
@@ -33,7 +36,6 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
   end
 
   before do
-    create :question, full_name: "FullName1"
     create :question, full_name: "FullName3"
     new_question.avatar = File.open(Rails.root.join(image_path), "rb")
     new_question.avatar_derivatives!
@@ -46,10 +48,8 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
 
     let(:prepared_fixture_file) do
       fixture_file.gsub(
-        /:avatarUrl|:correctAnswerValue|:correctAnswersCount/,
-        ":avatarUrl" => new_question.avatar(:normal).url,
-        ":correctAnswerValue" => answer.question.full_name,
-        ":correctAnswersCount" => result.answers.correct.count
+        /:avatarUrl/,
+        ":avatarUrl" => new_question.avatar(:normal).url
       )
     end
   end

--- a/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
+++ b/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
@@ -7,7 +7,7 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
   let(:schema_context) { { current_user: user } }
 
   let(:image_path) { "spec/fixtures/images/avatar.jpg" }
-
+  let(:new_question) { create :question, full_name: "FullName2" }
   let(:question) { create :question, full_name: "Ural Sadritdinov" }
   let(:result) { create :result, user: user, finish_at: 10.minutes.since }
   let!(:answer) { create :answer, correct: false, result: result, question: question, value: nil }
@@ -34,23 +34,22 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
 
   before do
     create :question, full_name: "FullName1"
-    create :question, full_name: "FullName2"
     create :question, full_name: "FullName3"
+    new_question.avatar = File.open(Rails.root.join(image_path), "rb")
+    new_question.avatar_derivatives!
+    new_question.save
     srand(777)
-    question.avatar = File.open(Rails.root.join(image_path), "rb")
-    question.avatar_derivatives!
-    question.save
   end
 
-  it_behaves_like "graphql request", "return correct_answer_value and question" do
+  it_behaves_like "graphql request", "return correct_answer_value, correct_answers_count and question" do
     let(:fixture_path) { "json/acceptance/graphql/send_answer_and_get_next_question/success.json" }
 
     let(:prepared_fixture_file) do
       fixture_file.gsub(
-        /:avatar_url|:correct_answer_value|:correct_answers_count/,
-        ":avatar_url" => question.avatar(:normal).url,
-        ":correct_answer_value" => answer.question.full_name,
-        ":correct_answers_count" => result.answers.correct.count
+        /:avatarUrl|:correctAnswerValue|:correctAnswersCount/,
+        ":avatarUrl" => new_question.avatar(:normal).url,
+        ":correctAnswerValue" => answer.question.full_name,
+        ":correctAnswersCount" => result.answers.correct.count
       )
     end
   end

--- a/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
@@ -9,7 +9,6 @@ describe SendAnswerAndGetNextQuestion::SetCorrectAnswersCount do
     }
   end
   let(:result) { create :result }
-  let(:correct_answers_count) { 3 }
 
   before do
     create :answer, result: result, correct: true
@@ -25,7 +24,7 @@ describe SendAnswerAndGetNextQuestion::SetCorrectAnswersCount do
     it "update correct answers count" do
       interactor.run
 
-      expect(context.correct_answers_count).to eq(correct_answers_count)
+      expect(context.correct_answers_count).to eq(3)
     end
   end
 end

--- a/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe SendAnswerAndGetNextQuestion::SetCorrectAnswersCount do
+  include_context "with interactor"
+
+  let(:initial_context) do
+    {
+      result: result
+    }
+  end
+  let(:result) { create :result }
+  let(:correct_answers_count) { 3 }
+
+  before do
+    create :answer, result: result, correct: true
+    create :answer, result: result, correct: true
+    create :answer, result: result, correct: true
+    create :answer, result: result, correct: false
+    create :answer, result: result, correct: false
+  end
+
+  describe ".call" do
+    it_behaves_like "success interactor"
+
+    it "update correct answers count" do
+      interactor.run
+
+      expect(context.correct_answers_count).to eq(correct_answers_count)
+    end
+  end
+end

--- a/spec/interactors/send_answer_and_get_next_question_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question_spec.rb
@@ -11,7 +11,8 @@ describe SendAnswerAndGetNextQuestion do
         SendAnswerAndGetNextQuestion::UpdateResultScore,
         SendAnswerAndGetNextQuestion::PrepareQuestionParams,
         FindRandomQuestion,
-        CreateResultAnswer
+        CreateResultAnswer,
+        SendAnswerAndGetNextQuestion::SetCorrectAnswersCount
       ]
     end
 


### PR DESCRIPTION
### Summary

Add field correctAnswerCount in mutation sendAnswerAndGetNextQuestion

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
mutation {
    sendAnswerAndGetNextQuestion(
      input: {
        gameId: #{result.id},
        value: "Ural Sadritdinov"
      }
    ) {
        correctAnswersCount
        correctAnswerValue
        question {
          answerOptions
          avatarUrl
        }
      }
    }
```

### References
https://app.clickup.com/t/1t7hyku 