### PR TITLE
[1vc8w1f] Add Status field for answers instead of correct

### DIFF
--- a/app/graphql/types/answer_type.rb
+++ b/app/graphql/types/answer_type.rb
@@ -3,6 +3,6 @@ module Types
     field :id, ID, null: false
     field :question, QuestionType, null: false
     field :value, String, null: false
-    field :correct, Boolean, null: false
+    field :status, String, null: false
   end
 end

--- a/app/interactors/create_result/prepare_params.rb
+++ b/app/interactors/create_result/prepare_params.rb
@@ -16,7 +16,7 @@ class CreateResult
         {
           question_id: answer[:question_id],
           value: answer[:value],
-          correct: question_correct?(answer)
+          status: status(answer)
         }
       end
     end
@@ -36,16 +36,17 @@ class CreateResult
     end
 
     def correct_answers_count
-      @correct_answers_count ||= prepared_answers_params.filter { |answer| answer[:correct] }.count
-    end
-
-    def answers_count
+      @correct_answers_count ||= prepared_answers_params.filter { |answer| answer[:status] == "correct" }.count
     end
 
     def question_correct?(answer)
       question = Question.find_by(id: answer[:question_id])
       context.fail!(error_data: error_data) if question.blank?
       question.full_name == answer[:value]
+    end
+
+    def status(answer)
+      question_correct?(answer) ? "correct" : "incorrect"
     end
 
     def error_data

--- a/app/interactors/create_result_answer.rb
+++ b/app/interactors/create_result_answer.rb
@@ -15,7 +15,7 @@ class CreateResultAnswer
 
   def answer_params
     {
-      correct: false,
+      status: "incorrect",
       question: question,
       result: result
     }

--- a/app/interactors/create_result_answer.rb
+++ b/app/interactors/create_result_answer.rb
@@ -15,7 +15,7 @@ class CreateResultAnswer
 
   def answer_params
     {
-      status: "incorrect",
+      status: "pending",
       question: question,
       result: result
     }

--- a/app/interactors/send_answer_and_get_next_question/update_previous_answer.rb
+++ b/app/interactors/send_answer_and_get_next_question/update_previous_answer.rb
@@ -14,8 +14,12 @@ class SendAnswerAndGetNextQuestion
     def answer_params
       {
         value: answer_value,
-        correct: answer_value_correct?
+        status: status
       }
+    end
+
+    def status
+      answer_value_correct? ? "correct" : "incorrect"
     end
 
     def answer_value_correct?

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -9,6 +9,6 @@ class Answer < ApplicationRecord
   validates :result, :question, presence: true
   enumerize :status, in: AVALIABLE_STATUSES, scope: :shallow, default: :pending
 
-  scope :answered, -> { where(status: [:correct, :incorrect]) }
+  scope :answered, -> { where(status: %i[correct incorrect]) }
   scope :last_week, -> { where("created_at > ?", 1.week.ago.beginning_of_day) }
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,10 +1,15 @@
 class Answer < ApplicationRecord
+  extend Enumerize
+
+  AVALIABLE_STATUSES = %w[correct incorrect current pending].freeze
+
   belongs_to :result
   belongs_to :question
 
   validates :result, :question, presence: true
+  enumerize :status, in: AVALIABLE_STATUSES, scope: :shallow, default: :pending
 
-  scope :correct, -> { where(correct: true) }
+  scope :correct, -> { where(status: "correct") }
   scope :answered, -> { where.not(value: nil) }
   scope :last_week, -> { where("created_at > ?", 1.week.ago.beginning_of_day) }
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -9,7 +9,6 @@ class Answer < ApplicationRecord
   validates :result, :question, presence: true
   enumerize :status, in: AVALIABLE_STATUSES, scope: :shallow, default: :pending
 
-  scope :correct, -> { where(status: "correct") }
-  scope :answered, -> { where.not(value: nil) }
+  scope :answered, -> { where(status: [:correct, :incorrect]) }
   scope :last_week, -> { where("created_at > ?", 1.week.ago.beginning_of_day) }
 end

--- a/db/migrate/20211129074314_add_status_column_to_answers.rb
+++ b/db/migrate/20211129074314_add_status_column_to_answers.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToAnswers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :answers, :status, :string, null: false  
+  end
+end

--- a/db/migrate/20211129202836_change_null_option_to_correct_field.rb
+++ b/db/migrate/20211129202836_change_null_option_to_correct_field.rb
@@ -1,0 +1,5 @@
+class ChangeNullOptionToCorrectField < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :answers, :correct, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_131321) do
+ActiveRecord::Schema.define(version: 2021_11_29_202836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -20,9 +20,10 @@ ActiveRecord::Schema.define(version: 2021_11_16_131321) do
     t.bigint "result_id", null: false
     t.bigint "question_id", null: false
     t.string "value"
-    t.boolean "correct", null: false
+    t.boolean "correct"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", null: false
     t.index ["created_at"], name: "index_answers_on_created_at"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["result_id"], name: "index_answers_on_result_id"

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     association :question
     association :result
     value { "value" }
-    status { "incorrect" }
+    status { "pending" }
   end
 end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     association :question
     association :result
     value { "value" }
-    correct { false }
+    status { "incorrect" }
   end
 end

--- a/spec/fixtures/json/acceptance/graphql/create_result/success.json
+++ b/spec/fixtures/json/acceptance/graphql/create_result/success.json
@@ -3,7 +3,7 @@
     "createResult": {
       "answers": [
         {
-          "correct": true,
+          "status": "correct",
           "question": {
             "fullName": "Name1",
             "id": "111"
@@ -11,7 +11,7 @@
           "value": "Name1"
         },
         {
-          "correct": true,
+          "status": "correct",
           "question": {
             "fullName": "Name2",
             "id": "222"
@@ -19,7 +19,7 @@
           "value": "Name2"
         },
         {
-          "correct": false,
+          "status": "incorrect",
           "question": {
             "fullName": "Name3",
             "id": "333"

--- a/spec/fixtures/json/acceptance/graphql/end_game/success.json
+++ b/spec/fixtures/json/acceptance/graphql/end_game/success.json
@@ -3,7 +3,7 @@
     "endGame": {
       "answers": [
         {
-          "correct": true,
+          "status": "correct",
           "question": {
             "fullName": "Name1",
             "id": "111"
@@ -11,7 +11,7 @@
           "value": "Name1"
         },
         {
-          "correct": false,
+          "status": "incorrect",
           "question": {
             "fullName": "Name2",
             "id": "222"
@@ -19,7 +19,7 @@
           "value": "Name1"
         },
         {
-          "correct": true,
+          "status": "correct",
           "question": {
             "fullName": "Name3",
             "id": "333"

--- a/spec/graphql/mutations/create_result_spec.rb
+++ b/spec/graphql/mutations/create_result_spec.rb
@@ -30,7 +30,7 @@ describe Mutations::CreateResult do
           }
           answers {
             value
-            correct
+            status
             question {
               id
               fullName

--- a/spec/graphql/mutations/end_game_spec.rb
+++ b/spec/graphql/mutations/end_game_spec.rb
@@ -22,7 +22,7 @@ describe Mutations::EndGame, type: :request do
         }
         answers {
           value
-          correct
+          status
           question {
             id
             fullName
@@ -37,9 +37,9 @@ describe Mutations::EndGame, type: :request do
     create :question, id: 111, full_name: "Name1"
     create :question, id: 222, full_name: "Name2"
     create :question, id: 333, full_name: "Name3"
-    create :answer, result: result, question_id: 111, value: "Name1", correct: true
-    create :answer, result: result, question_id: 222, value: "Name1", correct: false
-    create :answer, result: result, question_id: 333, value: "Name3", correct: true
+    create :answer, result: result, question_id: 111, value: "Name1", status: "correct"
+    create :answer, result: result, question_id: 222, value: "Name1", status: "incorrect"
+    create :answer, result: result, question_id: 333, value: "Name3", status: "correct"
   end
 
   it_behaves_like "graphql request", "returns updated user info" do

--- a/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
+++ b/spec/graphql/mutations/send_answer_and_get_next_question_spec.rb
@@ -12,8 +12,8 @@ describe Mutations::SendAnswerAndGetNextQuestion, type: :request do
   let(:new_question) { create :question, full_name: "FullName2" }
   let(:question) { create :question, full_name: "Ural Sadritdinov" }
   let(:result) { create :result, user: user, finish_at: 10.minutes.since }
-  let!(:answer_1) { create :answer, correct: false, result: result, question: question, value: nil }
-  let!(:answer_2) { create :answer, correct: true, result: result, question: old_question }
+  let!(:answer_1) { create :answer, status: "incorrect", result: result, question: question, value: nil }
+  let!(:answer_2) { create :answer, status: "correct", result: result, question: old_question }
 
   let(:query) do
     <<-GRAPHQL

--- a/spec/graphql/types/query_type_popularity_rating_spec.rb
+++ b/spec/graphql/types/query_type_popularity_rating_spec.rb
@@ -29,12 +29,12 @@ describe Types::QueryType do
     let(:question) { create :question, email: "email@flatstack.com" }
 
     before do
-      create :answer, question: question, correct: true
-      create :answer, question: question, correct: true
-      create :answer, question: question, correct: false
+      create :answer, question: question, status: "correct"
+      create :answer, question: question, status: "correct"
+      create :answer, question: question, status: "incorrect"
       create :answer, question: question, correct: false, created_at: 8.days.ago
-      create :answer, correct: true
-      create :answer, correct: false
+      create :answer, status: "correct"
+      create :answer, status: "incorrect"
     end
 
     it_behaves_like "graphql request", "gets popularity info" do

--- a/spec/graphql/types/query_type_results_board_spec.rb
+++ b/spec/graphql/types/query_type_results_board_spec.rb
@@ -43,9 +43,9 @@ describe Types::QueryType do
     create :result, score: 500, user: user3
     create :result, score: 100, user: user4
 
-    create :answer, result: current_user_result, correct: true
-    create :answer, result: current_user_result, correct: true
-    create :answer, result: current_user_result, correct: false
+    create :answer, result: current_user_result, status: "correct"
+    create :answer, result: current_user_result, status: "correct"
+    create :answer, result: current_user_result, status: "incorrect"
   end
 
   it_behaves_like "graphql request", "gets results info" do

--- a/spec/interactors/create_result/create_answers_spec.rb
+++ b/spec/interactors/create_result/create_answers_spec.rb
@@ -9,13 +9,13 @@ describe CreateResult::CreateAnswers do
   let(:prepared_answers_params) do
     [
       {
-        correct: true, question_id: 111, value: "Name1"
+        status: "correct", question_id: 111, value: "Name1"
       },
       {
-        correct: true, question_id: 222, value: "Name2"
+        status: "correct", question_id: 222, value: "Name2"
       },
       {
-        correct: false, question_id: 333, value: "Name4"
+        status: "incorrect", question_id: 333, value: "Name4"
       }
     ]
   end
@@ -36,7 +36,7 @@ describe CreateResult::CreateAnswers do
       interactor.run
 
       expect(Answer.count).to eq 3
-      expect(Answer.pluck(:correct)).to eq [true, true, false]
+      expect(Answer.pluck(:status)).to eq %w[correct correct incorrect]
     end
   end
 end

--- a/spec/interactors/create_result/prepare_params_spec.rb
+++ b/spec/interactors/create_result/prepare_params_spec.rb
@@ -29,13 +29,13 @@ describe CreateResult::PrepareParams do
   let(:expected_prepared_answers_params) do
     [
       {
-        correct: true, question_id: 111, value: "Name1"
+        status: "correct", question_id: 111, value: "Name1"
       },
       {
-        correct: true, question_id: 222, value: "Name2"
+        status: "correct", question_id: 222, value: "Name2"
       },
       {
-        correct: false, question_id: 333, value: "Name4"
+        status: "incorrect", question_id: 333, value: "Name4"
       }
     ]
   end

--- a/spec/interactors/create_result_answer_spec.rb
+++ b/spec/interactors/create_result_answer_spec.rb
@@ -22,7 +22,7 @@ describe CreateResultAnswer do
 
       expect(answer).to be_present
       expect(answer).to have_attributes(
-        correct: false,
+        status: "incorrect",
         question: question,
         result: result
       )

--- a/spec/interactors/create_result_answer_spec.rb
+++ b/spec/interactors/create_result_answer_spec.rb
@@ -22,7 +22,7 @@ describe CreateResultAnswer do
 
       expect(answer).to be_present
       expect(answer).to have_attributes(
-        status: "incorrect",
+        status: "pending",
         question: question,
         result: result
       )

--- a/spec/interactors/generate_popularity_rating_spec.rb
+++ b/spec/interactors/generate_popularity_rating_spec.rb
@@ -34,7 +34,7 @@ describe GeneratePopularityRating do
       create :answer, question: question, status: "correct"
       create :answer, question: question, status: "correct"
       create :answer, question: question, status: "incorrect"
-      create :answer, question: question, status: "incorrect", value: nil
+      create :answer, question: question, status: "pending", value: nil
       create :answer, question: question, status: "correct", created_at: 8.days.ago
       create :answer, status: "correct"
       create :answer, status: "incorrect"

--- a/spec/interactors/generate_popularity_rating_spec.rb
+++ b/spec/interactors/generate_popularity_rating_spec.rb
@@ -31,13 +31,13 @@ describe GeneratePopularityRating do
     end
 
     before do
-      create :answer, question: question, correct: true
-      create :answer, question: question, correct: true
-      create :answer, question: question, correct: false
-      create :answer, question: question, correct: false, value: nil
-      create :answer, question: question, correct: true, created_at: 8.days.ago
-      create :answer, correct: true
-      create :answer, correct: false
+      create :answer, question: question, status: "correct"
+      create :answer, question: question, status: "correct"
+      create :answer, question: question, status: "incorrect"
+      create :answer, question: question, status: "incorrect", value: nil
+      create :answer, question: question, status: "correct", created_at: 8.days.ago
+      create :answer, status: "correct"
+      create :answer, status: "incorrect"
     end
 
     describe ".call" do

--- a/spec/interactors/generate_results_board_spec.rb
+++ b/spec/interactors/generate_results_board_spec.rb
@@ -64,9 +64,9 @@ describe GenerateResultsBoard do
     create :result, score: 500, user: user3
     create :result, score: 100, user: user4
 
-    create :answer, result: current_user_result, correct: true
-    create :answer, result: current_user_result, correct: true
-    create :answer, result: current_user_result, correct: false
+    create :answer, result: current_user_result, status: "correct"
+    create :answer, result: current_user_result, status: "correct"
+    create :answer, result: current_user_result, status: "incorrect"
   end
 
   describe ".call" do

--- a/spec/interactors/send_answer_and_get_next_question/prepare_params_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/prepare_params_spec.rb
@@ -12,7 +12,7 @@ describe SendAnswerAndGetNextQuestion::PrepareParams do
   let(:current_user) { create :user }
   let(:params) { { game_id: result.id, value: "Denis Zaharov" } }
   let!(:result) { create :result, finish_at: 10.minutes.since, user: current_user }
-  let!(:answer) { create :answer, value: nil, status: "incorrect", question: question, result: result }
+  let!(:answer) { create :answer, value: nil, status: "pending", question: question, result: result }
   let(:question) { create :question, full_name: "Arthur Zaharov" }
 
   describe ".call" do

--- a/spec/interactors/send_answer_and_get_next_question/prepare_params_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/prepare_params_spec.rb
@@ -12,7 +12,7 @@ describe SendAnswerAndGetNextQuestion::PrepareParams do
   let(:current_user) { create :user }
   let(:params) { { game_id: result.id, value: "Denis Zaharov" } }
   let!(:result) { create :result, finish_at: 10.minutes.since, user: current_user }
-  let!(:answer) { create :answer, value: nil, correct: false, question: question, result: result }
+  let!(:answer) { create :answer, value: nil, status: "incorrect", question: question, result: result }
   let(:question) { create :question, full_name: "Arthur Zaharov" }
 
   describe ".call" do

--- a/spec/interactors/send_answer_and_get_next_question/prepare_question_params_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/prepare_question_params_spec.rb
@@ -10,9 +10,9 @@ describe SendAnswerAndGetNextQuestion::PrepareQuestionParams do
     }
   end
   let!(:result) { create :result }
-  let!(:answer_1) { create :answer, result: result, correct: false, question: question_1 }
+  let!(:answer_1) { create :answer, result: result, status: "incorrect", question: question_1 }
   let(:question_1) { create :question, id: 111 }
-  let!(:answer_2) { create :answer, result: result, correct: false, question: question_2 }
+  let!(:answer_2) { create :answer, result: result, status: "incorrect", question: question_2 }
   let(:question_2) { create :question, id: 232 }
   let(:current_user) { create :user }
   let(:filter_options) do

--- a/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/set_correct_answers_count_spec.rb
@@ -11,11 +11,11 @@ describe SendAnswerAndGetNextQuestion::SetCorrectAnswersCount do
   let(:result) { create :result }
 
   before do
-    create :answer, result: result, correct: true
-    create :answer, result: result, correct: true
-    create :answer, result: result, correct: true
-    create :answer, result: result, correct: false
-    create :answer, result: result, correct: false
+    create :answer, result: result, status: "correct"
+    create :answer, result: result, status: "correct"
+    create :answer, result: result, status: "correct"
+    create :answer, result: result, status: "incorrect"
+    create :answer, result: result, status: "incorrect"
   end
 
   describe ".call" do

--- a/spec/interactors/send_answer_and_get_next_question/update_previous_answer_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/update_previous_answer_spec.rb
@@ -10,7 +10,7 @@ describe SendAnswerAndGetNextQuestion::UpdatePreviousAnswer do
       correct_answer_value: correct_answer_value
     }
   end
-  let(:answer) { create :answer, value: "Arthur Zaharov", correct: true }
+  let(:answer) { create :answer, value: "Arthur Zaharov", status: "correct" }
   let(:correct_answer_value) { "Arthur Zaharov" }
 
   describe ".call" do
@@ -24,7 +24,7 @@ describe SendAnswerAndGetNextQuestion::UpdatePreviousAnswer do
 
         expect(answer).to have_attributes(
           value: "Denis Zaharov",
-          correct: false
+          status: "incorrect"
         )
       end
     end
@@ -39,7 +39,7 @@ describe SendAnswerAndGetNextQuestion::UpdatePreviousAnswer do
 
         expect(answer).to have_attributes(
           value: "Arthur Zaharov",
-          correct: true
+          status: "correct"
         )
       end
     end

--- a/spec/interactors/send_answer_and_get_next_question/update_result_score_spec.rb
+++ b/spec/interactors/send_answer_and_get_next_question/update_result_score_spec.rb
@@ -10,11 +10,11 @@ describe SendAnswerAndGetNextQuestion::UpdateResultScore do
   end
 
   let!(:result) { create :result, score: 0 }
-  let!(:correct_answer1) { create :answer, result: result, correct: true }
-  let!(:correct_answer2) { create :answer, result: result, correct: true }
-  let!(:correct_answer3) { create :answer, result: result, correct: true }
-  let!(:correct_answer4) { create :answer, result: result, correct: false }
-  let!(:correct_answer5) { create :answer, result: result, correct: false }
+  let!(:correct_answer1) { create :answer, result: result, status: "correct" }
+  let!(:correct_answer2) { create :answer, result: result, status: "correct" }
+  let!(:correct_answer3) { create :answer, result: result, status: "correct" }
+  let!(:correct_answer4) { create :answer, result: result, status: "incorrect" }
+  let!(:correct_answer5) { create :answer, result: result, status: "incorrect" }
   let(:answers_count) { result.answers.count }
 
   describe ".call" do


### PR DESCRIPTION
### Summary

Add Status field for answers instead of correct.

### How it works

None.

### Test plan

List of steps to manually test introduced functionality:

None.

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Created 2 migrations. First migration add attribute status with null = false option, second migration change a correct attribute null option true. 

### References
https://app.clickup.com/t/1vc8w1f
