### PR TITLE
Add default value to status

### DIFF
--- a/db/migrate/20211130171333_add_default_option_to_status.rb
+++ b/db/migrate/20211130171333_add_default_option_to_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultOptionToStatus < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :answers, :status, "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_202836) do
+ActiveRecord::Schema.define(version: 2021_11_30_171333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2021_11_29_202836) do
     t.boolean "correct"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status", null: false
+    t.string "status", default: "pending", null: false
     t.index ["created_at"], name: "index_answers_on_created_at"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["result_id"], name: "index_answers_on_result_id"


### PR DESCRIPTION
### Summary

Add default "pending" to status.

### How it works

None.

### Test plan

None.

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

```
a = Answer.where(correct: true)
a.update(status: "correct")
b = Answer.where(correct: false)
b.update(status: "incorrect")
c = Answer.where(correct: nil)
c.update(status: "pending")
```

### References
https://app.clickup.com/t/1vc8w1f
