### PR TITLE
[1wtvcgw] Add suggested index for answers table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   include ImageUploader::Attachment(:avatar)
 
-  ALLOWED_EMAIL_SUBDOMAINS = ["flatstack.com", "flatstack.dev", "scalewill.com"].freeze
+  ALLOWED_EMAIL_SUBDOMAINS = ["flatstack.com", "flatstack.dev", "scalewill.com", "launchpad-kazan.com"].freeze
 
   has_secure_password
   has_secure_token :password_reset_token

--- a/db/migrate/20211208095206_add_multiple_index_for_answers.rb
+++ b/db/migrate/20211208095206_add_multiple_index_for_answers.rb
@@ -3,5 +3,6 @@ class AddMultipleIndexForAnswers < ActiveRecord::Migration[6.0]
   
   def change
     add_index :answers, [:question_id, :created_at], algorithm: :concurrently
+    safety_assured { remove_column :results, :time_duration, :integer }
   end
 end

--- a/db/migrate/20211208095206_add_multiple_index_for_answers.rb
+++ b/db/migrate/20211208095206_add_multiple_index_for_answers.rb
@@ -1,0 +1,7 @@
+class AddMultipleIndexForAnswers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+  
+  def change
+    add_index :answers, [:question_id, :created_at], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20211208095206_add_multiple_index_for_answers.rb
+++ b/db/migrate/20211208095206_add_multiple_index_for_answers.rb
@@ -3,6 +3,5 @@ class AddMultipleIndexForAnswers < ActiveRecord::Migration[6.0]
   
   def change
     add_index :answers, [:question_id, :created_at], algorithm: :concurrently
-    safety_assured { remove_column :results, :time_duration, :integer }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_01_081122) do
+ActiveRecord::Schema.define(version: 2021_12_08_095206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "answers", force: :cascade do |t|
@@ -25,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_12_01_081122) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "status", default: "pending", null: false
     t.index ["created_at"], name: "index_answers_on_created_at"
+    t.index ["question_id", "created_at"], name: "index_answers_on_question_id_and_created_at"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["result_id"], name: "index_answers_on_result_id"
     t.index ["status"], name: "index_answers_on_status"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2021_12_01_081122) do
   create_table "results", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "score", default: 0, null: false
+    t.integer "time_duration", default: 30, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "finish_at"
@@ -88,9 +89,9 @@ ActiveRecord::Schema.define(version: 2021_12_01_081122) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "avatar_data"
     t.string "password_reset_token"
     t.datetime "password_reset_sent_at"
-    t.text "avatar_data"
     t.datetime "confirmed_at"
     t.integer "last_score", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 2021_12_08_095206) do
   create_table "results", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "score", default: 0, null: false
-    t.integer "time_duration", default: 30, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "finish_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define(version: 2021_12_08_095206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "answers", force: :cascade do |t|


### PR DESCRIPTION
### Summary

Add suggested index for answers table, and add new allowed email launchpad-kazan.

### How it works

None.

### Test plan

None.

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Add index_answers_on_question_id_and_created_at for answers table.

### References
https://app.clickup.com/t/1wtvcgw